### PR TITLE
Add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ base64 CertificateFile.p12 | pbcopy
 ```
 
 Paste the output of the above command into a secret called `CERTIFICATES_P12` and the password into `CERTIFICATES_P12_PASSWORD` into the GitHub Actions Secrets in the GitHub settings.
+
 ## Usage:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 First, generate your signing certificates in the XCode preferences. Click on the Accounts tab, select your user account and click Manage Certificates. Click the plus button and add the relevant certificates for the type of app you are developing.
 
-Next, create a .p12 file that combines your certificate and private key using [these instructions](https://calvium.com/how-to-make-a-p12-file/). 
+Next, create a .p12 file that combines all of your certificates and private keys using [these instructions](https://calvium.com/how-to-make-a-p12-file/). 
 
 Copy the .p12 format in base64:
 
@@ -27,7 +27,7 @@ with:
 
 ## Multiple Certificates
 
-If you need to add multiple certificates, repeat the steps above for each certificate and add duplicate action runs for each certificate.
+If you need to add multiple certificates, select them all in the keychain when creating your p12 file. You do not need multiple separate steps.
 
 ## Additional Arguments
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@
 [![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat)](LICENSE)
 [![PRs welcome!](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
+## Getting Started
+
+First, generate your signing certificates in the XCode preferences. Click on the Accounts tab, select your user account and click Manage Certificates. Click the plus button and add the relevant certificates for the type of app you are developing.
+
+Next, create a .p12 file that combines your certificate and private key using [these instructions](https://calvium.com/how-to-make-a-p12-file/). 
+
+Copy the .p12 format in base64:
+
+```
+base64 CertificateFile.p12 | pbcopy
+```
+
+Paste the output of the above command into a secret called `CERTIFICATES_P12` and the password into `CERTIFICATES_P12_PASSWORD` into the GitHub Actions Secrets in the GitHub settings.
 ## Usage:
 
 ```yaml
@@ -11,6 +24,10 @@ with:
   p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
   p12-password: ${{ secrets.CERTIFICATES_P12_PASSWORD }}
 ```
+
+## Multiple Certificates
+
+If you need to add multiple certificates, repeat the steps above for each certificate and add duplicate action runs for each certificate.
 
 ## Additional Arguments
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Getting Started
 
-First, generate your signing certificates in the XCode preferences. Click on the Accounts tab, select your user account and click Manage Certificates. Click the plus button and add the relevant certificates for the type of app you are developing.
+First, generate your signing certificates in the Xcode preferences. Click on the Accounts tab, select your user account and click Manage Certificates. Click the plus button and add the relevant certificates for the type of app you are developing.
 
 Next, create a .p12 file that combines all of your certificates and private keys using [these instructions](https://calvium.com/how-to-make-a-p12-file/). 
 


### PR DESCRIPTION
I've added some documentation that describes how to generate and prepare the certificates for adding to the GitHub Actions Secrets.

I you have any suggestions let me know.