### PR TITLE
test: bump checkout to v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   build: # make sure build/ci work properly
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - run: |
         npm install
         npm run all


### PR DESCRIPTION
Updates checkout from the outdated v1 to v3. v1 has been outdated since dec 2019