### PR TITLE
update to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ outputs:
   security-response:
     description: 'The output of the security commands.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'lock'

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "typescript": "^4.9.5"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "GitHub Action for Importing Code-signing Certificates into a Keychain",
   "main": "lib/main.js",
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
I updated the action runtime to node20 and edited it inside package.json 
it should fix the warning for [this](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) I ran the tests and they also passed, let me know if there is anything else to change. 