### PR TITLE
Support delete temp keychain before create a new one

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,4 +37,3 @@ runs:
 branding:
   icon: 'lock'
   color: 'blue'
-  

--- a/action.yml
+++ b/action.yml
@@ -37,3 +37,4 @@ runs:
 branding:
   icon: 'lock'
   color: 'blue'
+  

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
   p12-password:
     description: 'The password used to import the PKCS12 file.'
     required: true
+  delete-keychain-if-exists:
+    description: 'A boolean indicating whether to delete the keychain if it already exists. May need this on self-hosted runners.'
+    required: false
+    default: 'false'
 outputs:
   keychain-password:
     description: 'The password for temporary keychain.'

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,8 @@ async function run(): Promise<void> {
     let p12Filepath: string = core.getInput('p12-filepath')
     const p12FileBase64: string = core.getInput('p12-file-base64')
     const p12Password: string = core.getInput('p12-password')
+    const deleteKeychainIfExists: boolean =
+      core.getInput('delete-keychain-if-exists') === 'true'
 
     if (p12Filepath === '' && p12FileBase64 === '') {
       throw new Error(
@@ -37,6 +39,14 @@ async function run(): Promise<void> {
 
     core.setOutput('keychain-password', keychainPassword)
     core.setSecret(keychainPassword)
+
+    if (deleteKeychainIfExists) {
+      try {
+        await security.deleteKeychain(keychain)
+      } catch (error) {
+        core.warning(`Failed to delete keychain: ${error}`)
+      }
+    }
 
     await security.installCertIntoTemporaryKeychain(
       keychain,


### PR DESCRIPTION
Self-hosted runners need some kind of clean up. otherwise it can not create new keychain with same name.