### PR TITLE
Fix keychain deletion in multi-certificate workflows

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -28495,8 +28495,8 @@ var exports = __webpack_exports__;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core_1 = __nccwpck_require__(7484);
-const os_1 = __nccwpck_require__(857);
 const fs_1 = __nccwpck_require__(9896);
+const os_1 = __nccwpck_require__(857);
 const tmp_1 = __nccwpck_require__(1288);
 const security_1 = __nccwpck_require__(724);
 async function run() {
@@ -28539,7 +28539,11 @@ async function run() {
 async function cleanup() {
     try {
         const keychain = (0, core_1.getInput)('keychain');
-        await (0, security_1.deleteKeychain)(keychain);
+        const didCreateKeychain = (0, core_1.getInput)('create-keychain') === 'true';
+        // only delete the keychain if it was created by this action
+        if (didCreateKeychain) {
+            await (0, security_1.deleteKeychain)(keychain);
+        }
     }
     catch (error) {
         if (error instanceof Error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,13 @@
 import {
+  getInput,
   getState,
   saveState,
-  getInput,
   setFailed,
   setOutput,
   setSecret
 } from '@actions/core'
-import {platform} from 'os'
 import {writeFileSync} from 'fs'
+import {platform} from 'os'
 import {fileSync} from 'tmp'
 import {deleteKeychain, installCertIntoTemporaryKeychain} from './security'
 
@@ -64,8 +64,12 @@ async function run(): Promise<void> {
 async function cleanup(): Promise<void> {
   try {
     const keychain: string = getInput('keychain')
+    const didCreateKeychain: boolean = getInput('create-keychain') === 'true'
 
-    await deleteKeychain(keychain)
+    // only delete the keychain if it was created by this action
+    if (didCreateKeychain) {
+      await deleteKeychain(keychain)
+    }
   } catch (error) {
     if (error instanceof Error) {
       setFailed(error.message)


### PR DESCRIPTION
## Problem Description
When `import-codesign-certs@v5` is used multiple times in the same workflow, the same keychain is deleted more than once during the post-job cleanup phase. This results in workflow failures, as the second deletion attempt leads to the following error:

```
security: SecKeychainDelete: The specified keychain could not be found.
Error: The process '/usr/bin/security' failed with exit code 50
```

This issue occurs when multiple certificates, such as development and distribution certificates, are imported in separate steps using the same keychain.

## Changes Made
- Added a check to only attempt keychain deletion if it was created by the current action instance.

## Example Workflow
This PR fixes issues with workflows structured like:

```yaml
- name: Import Development Certificate
  id: create_keychain
  uses: apple-actions/import-codesign-certs@v5
  with:
    p12-file-base64: ${{ inputs.p12-file-development }}
    p12-password: ${{ inputs.p12-file-development-password }}
- name: Import Distribution Certificate
  uses: apple-actions/import-codesign-certs@v5
  with:
    create-keychain: false
    keychain-password: "${{ steps.create_keychain.outputs.keychain-password }}"
    p12-file-base64: ${{ inputs.p12-file-distribution }}
    p12-password: ${{ inputs.p12-file-distribution-password }}
```

## Notes

I know it's possible to import multiple certificates at once, as mentioned in the `README.md`. However, I prefer to keep the certificate files separate since they are also used in other locations.