### PR TITLE
Delete keychain only if it was created

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -28539,7 +28539,11 @@ async function run() {
 async function cleanup() {
     try {
         const keychain = (0, core_1.getInput)('keychain');
-        await (0, security_1.deleteKeychain)(keychain);
+        const createdKeychain = (0, core_1.getInput)('create-keychain') === 'true';
+        // Only delete the keychain if it was created by the module
+        if (createdKeychain) {
+            await (0, security_1.deleteKeychain)(keychain);
+        }
     }
     catch (error) {
         if (error instanceof Error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,8 +64,12 @@ async function run(): Promise<void> {
 async function cleanup(): Promise<void> {
   try {
     const keychain: string = getInput('keychain')
+    const createdKeychain: boolean = getInput('create-keychain') === 'true'
 
-    await deleteKeychain(keychain)
+    // Only delete the keychain if it was created by the module
+    if (createdKeychain) {
+      await deleteKeychain(keychain)
+    }
   } catch (error) {
     if (error instanceof Error) {
       setFailed(error.message)


### PR DESCRIPTION
We had a situation where we added multiple keys to a single keychain in multiple steps.  Each step tried to delete the keychain, and the pipeline would fail.  This runs the delete keychain command only if the originating step created the keychain.  
