### PR TITLE
allow pkgbuild to access imported keys

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -88,6 +88,8 @@ async function importPkcs12(keychain, p12FilePath, p12Password, options) {
         '-T',
         '/usr/bin/security',
         '-T',
+        '/usr/bin/pkgbuild',
+        '-T',
         '/usr/bin/productbuild',
         '-P',
         p12Password

--- a/src/security.ts
+++ b/src/security.ts
@@ -104,6 +104,8 @@ async function importPkcs12(
     '-T',
     '/usr/bin/security',
     '-T',
+    '/usr/bin/pkgbuild',
+    '-T',
     '/usr/bin/productbuild',
     '-P',
     p12Password


### PR DESCRIPTION
We create a simple pkg installer that doesn't need to go through productbuild, but ran into issues because pkgbuild was not allowed to use the signing keys.  This allows pkgbuild to also use the keys.  